### PR TITLE
Leakchecker{}: Create visualizing function that shows the changes in the number of goroutines.

### DIFF
--- a/leakdetect.go
+++ b/leakdetect.go
@@ -41,5 +41,5 @@ func (l *LeakDetect) stop() {
 		panic("This code may cause goroutine leak")
 	}
 
-	fmt.Println("======= LeakDetect End =======")
+	fmt.Println("=======  LeakDetect End  =======")
 }

--- a/leakgraph.go
+++ b/leakgraph.go
@@ -14,16 +14,13 @@ type LeakChecker struct {
 	done 					chan bool
 }
 
-func (l *LeakChecker) start() {
-	// ticker := time.NewTicker(1 * time.Millisecond)
- 	// defer ticker.Stop()
-
+func (l *LeakChecker) start(duration time.Duration) {
+	l.goroutineData = append(l.goroutineData, float64(runtime.NumGoroutine()))
 	for {
 		select {
-		case <- l.done:
+		case  <- l.done:
 			return
-		case <- time.After(1 * time.Millisecond):
-			fmt.Println("oi")
+		case <- time.After(duration):
 			l.goroutineData = append(l.goroutineData, float64(runtime.NumGoroutine()))
 		}
 	}
@@ -49,5 +46,5 @@ func (l *LeakChecker) stop() {
 		panic("This code may cause goroutine leak")
 	}
 
-	fmt.Println("======= LeakChecker End =======")
+	fmt.Println("=======  LeakChecker End  =======")
 }

--- a/leakgraph_test.go
+++ b/leakgraph_test.go
@@ -5,12 +5,13 @@ import (
 	"sync"
 	"fmt"
 	"runtime"
+	"time"
 )
 
 func Test3(t *testing.T) {
-	leakChecker := LeakChecker{runtime.NumGoroutine(), []float64{1, 2, 4, 6, 10, 7, 4, 2, 1}, make(chan bool)}
-	// leakChecker := LeakChecker{runtime.NumGoroutine(), []float64{}, make(chan bool)}
-	go leakChecker.start()
+	// leakChecker := LeakChecker{runtime.NumGoroutine(), []float64{1, 2, 4, 6, 10, 7, 4, 2, 1}, make(chan bool)}
+	leakChecker := LeakChecker{runtime.NumGoroutine(), []float64{}, make(chan bool)}
+	go leakChecker.start(100 * time.Microsecond)
 	defer leakChecker.stop()
 
 	fmt.Println("main", goid())


### PR DESCRIPTION
### What can a user do?
Users can create a graph that shows the changes in the number of goroutines with Leakchecker{}. Not only detect goroutine leaks automatically, but you can also get information on changes in the number of goroutines.

### How to use it?
You can use Leakchecker{} like below.

```
func Test(t *testing.T) {
	leakChecker := LeakChecker{runtime.NumGoroutine(), []float64{}, make(chan bool)}
	go leakChecker.start(100 * time.Microsecond)
	defer leakChecker.stop()

        /*
              Main test code 
        */
}
```

It is necessary to set how many goroutine numbers are to be examined and at what time interval.
`Second > Millisecond > Microsecond > Nanosecond`

### What kind of output can you get?
<img width="237" alt="Screenshot 2023-06-25 at 23 55 08" src="https://github.com/kantanakamura/goleakalert/assets/96579474/bd2bcc58-1207-441b-a13c-2664dc25a9ab">
